### PR TITLE
Format links using Latex style rather than Org headings

### DIFF
--- a/config.sty
+++ b/config.sty
@@ -1,3 +1,3 @@
 \setlist{leftmargin=0.25in,nosep}
 \setsansfont{Latin Modern Sans}
-\linespread{1.5}
+\linespread{1.45}

--- a/education.org
+++ b/education.org
@@ -1,5 +1,5 @@
 * Education
-** BSc, Computer Science at [[https://www.uvic.ca/][University of Victoria]]
+** BSc, Computer Science at [[https://uvic.ca][University of Victoria]]
 *** Sept 2017 - Present
 *Victoria, BC*
 - Expecting Graduation in 2021

--- a/experience.org
+++ b/experience.org
@@ -1,3 +1,6 @@
+#+BEGIN_EXPORT Latex
+\renewcommand{\href}[2]{\changeurlcolor{pumpkin}\oldhref{#1}{#2}}
+#+END_EXPORT
 * Experience
 ** Line Cook at [[https://spitfiregrill.ca][Spitfire Grill]]
 *** June 2017 - October 2017

--- a/experience.org
+++ b/experience.org
@@ -1,5 +1,5 @@
 * Experience
-** Line Cook at [[https://www.spitfiregrill.ca/][Spitfire Grill]]
+** Line Cook at [[https://spitfiregrill.ca][Spitfire Grill]]
 *** June 2017 - October 2017
 *Sidney, BC*
 - Prepare food orders quickly and accurately using the appropriate procedures.

--- a/experience.org
+++ b/experience.org
@@ -1,5 +1,5 @@
 #+BEGIN_EXPORT Latex
-\renewcommand{\href}[2]{\changeurlcolor{pumpkin}\oldhref{#1}{#2}}
+\toggleurlstyle
 #+END_EXPORT
 * Experience
 ** Line Cook at [[https://spitfiregrill.ca][Spitfire Grill]]

--- a/mycv.sty
+++ b/mycv.sty
@@ -95,6 +95,8 @@
 \hypersetup{colorlinks=true, urlcolor={pumpkin}}
 \newcommand{\changeurlcolor}[1]{\hypersetup{urlcolor=#1}}
 \newcommand{\boldurl}[2]{\oldhref{#1}{\bfseries{\textit{#2}}}}
+\newcommand{\toggleurlstyle}{\renewcommand{\href}[2]{\changeurlcolor{pumpkin}\oldhref{#1}{#2}}}
+
 
 %% Bold URLs
 \let\oldhref\href

--- a/mycv.sty
+++ b/mycv.sty
@@ -42,7 +42,7 @@
 \newcommand{\resheader}[7]{
     \begin{tabular*}{\textwidth}{l@{\extracolsep{\fill}}ll}
     \textbf{\huge #1}                                     & \large \faComment #3 & \large \faHome #5\\
-    \hspace{0.15cm} \large \faGlobe \hspace{0.03cm} \large \href{#2}{#2} & \large \faPhone   #4 & \hspace{0.29cm} \large        #6 \\
+    \hspace{0.15cm} \large \faGlobe \hspace{0.03cm} \large \boldurl{#2}{#2} & \large \faPhone   #4 & \hspace{0.29cm} \large        #6 \\
     \hspace{0.15cm}  & \hspace{0.15cm} & \hspace{0.29cm} \large #7\\
     \end{tabular*}
     \\
@@ -94,9 +94,10 @@
 %% URL Colors
 \hypersetup{colorlinks=true, urlcolor={pumpkin}}
 \newcommand{\changeurlcolor}[1]{\hypersetup{urlcolor=#1}}
+\newcommand{\boldurl}[2]{\oldhref{#1}{\bfseries{\textit{#2}}}}
 
 %% Bold URLs
 \let\oldhref\href
 \renewcommand{\href}[2]{\changeurlcolor{black}\oldhref{#1}{#2}
                         \changeurlcolor{pumpkin} \newline
-                        \oldhref{#1}{{\bfseries{\textit{\StrSubstitute{#1}{https://}{}}}}}}
+                        \oldhref{#1}{\StrSubstitute{#1}{https://}{}}}

--- a/mycv.sty
+++ b/mycv.sty
@@ -20,7 +20,8 @@
   titlesec,
   fontspec,
   fontawesome,
-  enumitem
+  enumitem,
+  xstring
 }
 \RequirePackage[empty]{fullpage}
 
@@ -92,7 +93,10 @@
 
 %% URL Colors
 \hypersetup{colorlinks=true, urlcolor={pumpkin}}
+\newcommand{\changeurlcolor}[1]{\hypersetup{urlcolor=#1}}
 
 %% Bold URLs
 \let\oldhref\href
-\renewcommand{\href}[2]{\oldhref{#1}{\bfseries{\textit#2}}}
+\renewcommand{\href}[2]{\changeurlcolor{black}\oldhref{#1}{#2}
+                        \changeurlcolor{pumpkin} \newline
+                        \oldhref{#1}{{\bfseries{\textit{\StrSubstitute{#1}{https://}{}}}}}}

--- a/projects.org
+++ b/projects.org
@@ -1,17 +1,13 @@
 * Projects
-** Woofers 3D
-** [[https://github.com/woofers/woofers3d][github.com/woofers/woofers3d]]
+** [[https://github.com/woofers/woofers3d][Woofers 3D]]
 *** Java
 /Woofers 3D/ is a Java API that attempts to unify the features of Box2D and Bullet Physics into a simple yet capable package that can be run on nearly any device via LibGDX. Supports modern features such as ray tracing, chasing camera, game states and 3D model importing.
-** Whale
-** [[https://github.com/woofers/whale][github.com/woofers/whale]]
+** [[https://github.com/woofers/whale][Whale]]
 *** Haxe
 /Whale/ is a 2D arcade style game built using HaxeFlixel. It features score tracking, level generation and responsive accelerometer controls. Game is fully completed and can be downloaded from the Google Play Store.
-** Kangaroo Country
-** [[https://github.com/woofers/kangaroo-country][github.com/woofers/kangaroo-country]]
+** [[https://github.com/woofers/kangaroo-country][Kangaroo Country]]
 *** Actionscript 3
 /Kangaroo Country/ is a 2D side-scrolling game built in Actionscrpt 3. Game features two fully completed levels where you play as two distinct characters in-order to solve platforming puzzles. As levels are imported from JSON based Tile Editor files, more levels can be dynamically added and created by others.
-** Fox Hole
-** [[https://github.com/woofers/fox-hole][github.com/woofers/fox-hole]]
+** [[https://github.com/woofers/fox-hole][Fox Hole]]
 *** Javascript
 /Fox Hole/ is a 2D proof of concept game built in Javascript with Phaser. You play as a fox sneaking past enemy crocodiles using underground tunnels in order to save your brother. It features checkpoints and enemies complete with very basic AI.


### PR DESCRIPTION
Removes the use of duplicate subsections to display link URLs for printed copies.  Instead the Latex URL alias will print the full URL below the heading.